### PR TITLE
Resolve 1 mismatch stubbing in GameMasterControllerTest.java

### DIFF
--- a/Backend/src/test/java/com/yodigi/quiplash/controllers/GameMasterControllerTest.java
+++ b/Backend/src/test/java/com/yodigi/quiplash/controllers/GameMasterControllerTest.java
@@ -105,7 +105,7 @@ public class GameMasterControllerTest {
         game2.setId(2L);
         game2.setContenders(contenders);
         doReturn(game).when(repoUtil).findGameById(1L);
-        doReturn(new HashSet<>()).when(retrieveQuestionsUtil).getRandomQuestions(2);
+        doReturn(new HashSet<>()).when(retrieveQuestionsUtil).getRandomQuestions(6);
         doReturn(game2).when(repoUtil).findGameById(2L);
 
         mockMvc.perform(post("/game/1/start-game"))


### PR DESCRIPTION
We are researchers and analyzed the test doubles (mocks) in the test code of the project. In our analysis of the project, we observed that

1 stubbing which stubbed `getRandomQuestion` method is created in `GameMasterControllerTest.givenValidGameIdAndCurrentRoundIsZero_whenCallingStartGame_thenStartGameAndIncrementRoundCountAndUpdatePhase`, was stubbed with argument 2, but in actual execution, it was called with argument 6, ,resulting in a mismatched stubbing.

Mismatched stubbing occurs when a mocked method is stubbed with specific arguments in a test but later invoked with different arguments in the code, potentially causing unexpected behavior. Mockito recommends addressing these issues, (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

We propose a solution below to resolve the mismatch stubbing.